### PR TITLE
Handle server to server notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ end
 
 We strongly recommend to use environment variables for these values.
 
-Apple sign-in workflow:
+### Apple sign-in workflow:
 
 ![alt text](https://docs-assets.developer.apple.com/published/360d59b776/rendered2x-1592224731.png)
 
 For more information, check the [Apple oficial documentation](https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api).
 
-Validate JWT token and get user information:
+### Validate JWT token and get user information:
 
 ```ruby
 # with a valid JWT
@@ -79,7 +79,7 @@ AppleAuth::UserIdentity.new(user_id, invalid_jwt_token).validate!
 >>  AppleAuth::Conditions::JWTValidationError
 ```
 
-Verify user identity and get access and refresh tokens:
+### Verify user identity and get access and refresh tokens:
 
 ```ruby
 code = 'cfb77c21ecd444390a2c214cd33decdfb.0.mr...'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AppleAuth
 
-[![CI](https://api.travis-ci.org/rootstrap/apple_auth.svg?branch=master)](https://travis-ci.org/github/rootstrap/apple_auth)
+[![CI](https://api.travis-ci.com/rootstrap/apple_auth.svg?branch=master)](https://travis-ci.com/github/rootstrap/apple_auth)
 [![Maintainability](https://api.codeclimate.com/v1/badges/78453501221a76e3806e/maintainability)](https://codeclimate.com/github/rootstrap/apple_sign_in/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/78453501221a76e3806e/test_coverage)](https://codeclimate.com/github/rootstrap/apple_sign_in/test_coverage)
 

--- a/lib/apple_auth.rb
+++ b/lib/apple_auth.rb
@@ -22,6 +22,7 @@ require 'apple_auth/helpers/conditions/exp_condition'
 require 'apple_auth/helpers/conditions/iat_condition'
 require 'apple_auth/helpers/conditions/iss_condition'
 require 'apple_auth/helpers/jwt_conditions'
+require 'apple_auth/helpers/jwt_decoder'
 
 require 'apple_auth/user_identity'
 require 'apple_auth/token'

--- a/lib/apple_auth.rb
+++ b/lib/apple_auth.rb
@@ -23,7 +23,9 @@ require 'apple_auth/helpers/conditions/iat_condition'
 require 'apple_auth/helpers/conditions/iss_condition'
 require 'apple_auth/helpers/jwt_conditions'
 require 'apple_auth/helpers/jwt_decoder'
+require 'apple_auth/helpers/jwt_server_conditions'
 
+require 'apple_auth/server_identity'
 require 'apple_auth/user_identity'
 require 'apple_auth/token'
 

--- a/lib/apple_auth/helpers/jwt_decoder.rb
+++ b/lib/apple_auth/helpers/jwt_decoder.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: false
+
+module AppleAuth
+  class JWTDecoder
+    APPLE_KEY_URL = 'https://appleid.apple.com/auth/keys'.freeze
+
+    attr_reader :jwt
+
+    def initialize(jwt)
+      @jwt = jwt
+    end
+
+    def call
+      decoded.first
+    end
+
+    private
+
+    def decoded
+      key_hash = apple_key_hash(jwt)
+      apple_jwk = JWT::JWK.import(key_hash)
+      JWT.decode(jwt, apple_jwk.public_key, true, algorithm: key_hash['alg'])
+    end
+
+    def apple_key_hash(jwt)
+      response = Net::HTTP.get(URI.parse(APPLE_KEY_URL))
+      certificate = JSON.parse(response)
+      matching_key = certificate['keys'].select { |key| key['kid'] == jwt_kid(jwt) }
+      ActiveSupport::HashWithIndifferentAccess.new(matching_key.first)
+    end
+
+    def jwt_kid(jwt)
+      header = JSON.parse(Base64.decode64(jwt.split('.').first))
+      header['kid']
+    end
+  end
+end

--- a/lib/apple_auth/helpers/jwt_server_conditions.rb
+++ b/lib/apple_auth/helpers/jwt_server_conditions.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: false
+
+module AppleAuth
+  class JWTServerConditions
+    include Conditions
+
+    CONDITIONS = [
+      AudCondition,
+      IatCondition,
+      IssCondition
+    ].freeze
+
+    attr_reader :decoded_jwt
+
+    def initialize(decoded_jwt)
+      @decoded_jwt = decoded_jwt
+    end
+
+    def validate!
+      JWT::ClaimsValidator.new(decoded_jwt).validate! && jwt_conditions_validate!
+    rescue JWT::InvalidPayload => e
+      raise JWTValidationError, e.message
+    end
+
+    private
+
+    def jwt_conditions_validate!
+      conditions_results = CONDITIONS.map do |condition|
+        condition.new(decoded_jwt).validate!
+      end
+      conditions_results.all? { |value| value == true }
+    end
+  end
+end

--- a/lib/apple_auth/server_identity.rb
+++ b/lib/apple_auth/server_identity.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module AppleAuth
+  class ServerIdentity
+    attr_reader :jwt
+
+    def initialize(jwt)
+      @jwt = jwt
+    end
+
+    def validate!
+      token_data = JWTDecoder.new(jwt).call
+
+      JWTServerConditions.new(token_data).validate!
+
+      token_data.symbolize_keys
+    end
+  end
+end

--- a/lib/apple_auth/user_identity.rb
+++ b/lib/apple_auth/user_identity.rb
@@ -2,8 +2,6 @@
 
 module AppleAuth
   class UserIdentity
-    APPLE_KEY_URL = 'https://appleid.apple.com/auth/keys'
-
     attr_reader :user_identity, :jwt
 
     def initialize(user_identity, jwt)
@@ -12,31 +10,11 @@ module AppleAuth
     end
 
     def validate!
-      token_data = decoded_jwt
+      token_data = JWTDecoder.new(jwt).call
 
       JWTConditions.new(user_identity, token_data).validate!
 
       token_data.symbolize_keys
-    end
-
-    private
-
-    def decoded_jwt
-      key_hash = apple_key_hash
-      apple_jwk = JWT::JWK.import(key_hash)
-      JWT.decode(jwt, apple_jwk.public_key, true, algorithm: key_hash['alg']).first
-    end
-
-    def apple_key_hash
-      response = Net::HTTP.get(URI.parse(APPLE_KEY_URL))
-      certificate = JSON.parse(response)
-      matching_key = certificate['keys'].select { |key| key['kid'] == jwt_kid }
-      ActiveSupport::HashWithIndifferentAccess.new(matching_key.first)
-    end
-
-    def jwt_kid
-      header = JSON.parse(Base64.decode64(jwt.split('.').first))
-      header['kid']
     end
   end
 end

--- a/spec/helpers/jwt_conditions_spec.rb
+++ b/spec/helpers/jwt_conditions_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe AppleAuth::JWTConditions do
         end
       end
 
-      context 'when exp is not a integer' do
+      context 'when iat is not a integer' do
         let(:jwt_iat) { Time.now }
 
         it 'raises an exception' do
@@ -59,7 +59,7 @@ RSpec.describe AppleAuth::JWTConditions do
       end
     end
 
-    context 'when jwt iss is different to user_identity' do
+    context 'when jwt sub is different to user_identity' do
       let(:jwt_sub) { '1234.5678.911' }
 
       it 'raises an exception' do
@@ -69,7 +69,7 @@ RSpec.describe AppleAuth::JWTConditions do
       end
     end
 
-    context 'when jwt_aud is different to apple_client_id' do
+    context 'when jwt aud is different to apple_client_id' do
       let(:jwt_aud) { 'net.apple_auth' }
 
       it 'raises an exception' do

--- a/spec/helpers/jwt_server_conditions_spec.rb
+++ b/spec/helpers/jwt_server_conditions_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe AppleAuth::JWTServerConditions do
+  let(:jwt_sub) { '820417.faa325acbc78e1be1668ba852d492d8a.0219' }
+  let(:jwt_iss) { 'https://appleid.apple.com' }
+  let(:jwt_aud) { 'com.apple_auth' }
+  let(:jwt_iat) { Time.now.to_i }
+  let(:jwt) do
+    {
+      iss: jwt_iss,
+      aud: jwt_aud,
+      iat: jwt_iat,
+      events: '{
+        "type": "email-enabled",
+        "sub": "820417.faa325acbc78e1be1668ba852d492d8a.0219",
+        "email": "ep9ks2tnph@privaterelay.appleid.com",
+        "is_private_email": "true",
+        "event_time": 1508184845
+      }'
+    }
+  end
+
+  let(:decoded_jwt) { ActiveSupport::HashWithIndifferentAccess.new(jwt) }
+
+  before do
+    AppleAuth.config.apple_client_id = 'com.apple_auth'
+  end
+
+  subject(:jwt_conditions_helper) { described_class.new(decoded_jwt) }
+
+  context '#valid?' do
+    context 'when decoded jwt attributes are valid' do
+      it 'returns true' do
+        expect(jwt_conditions_helper.validate!).to eq(true)
+      end
+    end
+
+    context 'when jwt has incorrect type attributes' do
+      context 'when iat is not a integer' do
+        let(:jwt_iat) { Time.now }
+
+        it 'raises an exception' do
+          expect { jwt_conditions_helper.validate! }.to raise_error(
+            AppleAuth::Conditions::JWTValidationError
+          )
+        end
+      end
+    end
+
+    context 'when jwt_aud is different to apple_client_id' do
+      let(:jwt_aud) { 'net.apple_auth' }
+
+      it 'raises an exception' do
+        expect { jwt_conditions_helper.validate! }.to raise_error(
+          AppleAuth::Conditions::JWTValidationError, 'jwt_aud is different to apple_client_id'
+        )
+      end
+    end
+
+    context 'when jwt_iss is different to apple_iss' do
+      let(:jwt_iss) { 'https://appleid.apple.net' }
+
+      it 'raises an exception' do
+        expect { jwt_conditions_helper.validate! }.to raise_error(
+          AppleAuth::Conditions::JWTValidationError, 'jwt_iss is different to apple_iss'
+        )
+      end
+    end
+
+    context 'when jwt_iat is greater than now' do
+      let(:jwt_iat) { (Time.now + 5.minutes).to_i }
+
+      it 'raises an exception' do
+        expect { jwt_conditions_helper.validate! }.to raise_error(
+          AppleAuth::Conditions::JWTValidationError, 'jwt_iat is greater than now'
+        )
+      end
+    end
+  end
+end

--- a/spec/server_identity_spec.rb
+++ b/spec/server_identity_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe AppleAuth::ServerIdentity do
+  let(:jwt_iss) { 'https://appleid.apple.com' }
+  let(:jwt_aud) { 'com.apple_sign_in' }
+  let(:jwt_iat) { Time.now.to_i }
+  let(:private_key) { OpenSSL::PKey::RSA.generate(2048) }
+  let(:jwk) { JWT::JWK.new(private_key) }
+  let(:jwt) do
+    {
+      iss: jwt_iss,
+      aud: jwt_aud,
+      iat: jwt_iat,
+      events: '{
+        "type": "email-enabled",
+        "sub": "820417.faa325acbc78e1be1668ba852d492d8a.0219",
+        "email": "ep9ks2tnph@privaterelay.appleid.com",
+        "is_private_email": "true",
+        "event_time": 1508184845
+      }'
+    }
+  end
+
+  let(:signed_jwt) { JWT.encode(jwt, jwk.keypair, 'RS256', kid: jwk.kid) }
+  let(:exported_private_key) { JWT::JWK::RSA.new(private_key).export.merge({ alg: 'RS256' }) }
+  let(:apple_body) { [exported_private_key] }
+
+  before do
+    stub_request(:get, 'https://appleid.apple.com/auth/keys')
+      .to_return(
+        body: {
+          keys: apple_body
+        }.to_json,
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      )
+    AppleAuth.config.apple_client_id = jwt_aud
+  end
+
+  subject(:server_identity_service) { described_class.new(signed_jwt) }
+
+  context '#valid?' do
+    context 'when the parameters of the initilizer are correct' do
+      it 'returns the validated JWT attributes' do
+        expect(server_identity_service.validate!).to eq(jwt)
+      end
+
+      context 'when there are more than one private keys' do
+        let(:private_key_two) { OpenSSL::PKey::RSA.generate(2048) }
+        let(:exported_private_key_two) do
+          JWT::JWK::RSA.new(private_key).export.merge({ alg: 'RS256' })
+        end
+
+        it 'returns the validated JWT attributes' do
+          expect(server_identity_service.validate!).to eq(jwt)
+        end
+      end
+    end
+
+    context 'when the parameters of the initilizer are not correct' do
+      let(:jwt) do
+        {
+          iss: 'https://not-an-appleid.com',
+          aud: jwt_aud,
+          iat: jwt_iat
+        }
+      end
+
+      it 'raises an exception' do
+        expect { server_identity_service.validate! }.to raise_error(
+          AppleAuth::Conditions::JWTValidationError
+        )
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,14 +4,14 @@ require 'rspec'
 require 'action_controller/railtie'
 require 'generator_spec'
 require 'bundler/setup'
-require 'simplecov'
 require 'webmock/rspec'
 
-require './lib/apple_auth'
-
+require 'simplecov'
 SimpleCov.start do
   add_filter '/spec/'
 end
+
+require './lib/apple_auth'
 
 require 'apple_auth/base'
 

--- a/spec/user_identity_spec.rb
+++ b/spec/user_identity_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe AppleAuth::UserIdentity do
   end
   let(:signed_jwt) { JWT.encode(jwt, jwk.keypair, 'RS256', kid: jwk.kid) }
   let(:exported_private_key) { JWT::JWK::RSA.new(private_key).export.merge({ alg: 'RS256' }) }
+  let(:apple_body) { [exported_private_key] }
 
   before do
     stub_request(:get, 'https://appleid.apple.com/auth/keys')
@@ -41,7 +42,6 @@ RSpec.describe AppleAuth::UserIdentity do
 
   context '#valid?' do
     context 'when the parameters of the initilizer are correct' do
-      let(:apple_body) { [exported_private_key] }
       let(:user_identity) { '1234.5678.910' }
       let(:uid) { user_identity }
 
@@ -55,8 +55,6 @@ RSpec.describe AppleAuth::UserIdentity do
           JWT::JWK::RSA.new(private_key).export.merge({ alg: 'RS256' })
         end
 
-        let(:apple_body) { [exported_private_key] }
-
         it 'returns the validated JWT attributes' do
           expect(user_identity_service.validate!).to eq(jwt)
         end
@@ -64,7 +62,6 @@ RSpec.describe AppleAuth::UserIdentity do
     end
 
     context 'when the parameters of the initilizer are not correct' do
-      let(:apple_body) { [exported_private_key] }
       let(:user_identity) { '1234.5678.910' }
       let(:uid) { '1234.5678.911' }
 


### PR DESCRIPTION
### Summary

As described in [Processing Changes for Sign in with Apple Accounts]( https://developer.apple.com/documentation/sign_in_with_apple/processing_changes_for_sign_in_with_apple_accounts)
**NOTE:** The Apple documentation states the events attribute as an array but is in fact a stringified json object

Introducing a new class: `AppleAuth::ServerIdentity` which validates the jwt token and claims

```ruby
# with a valid JWT
params[:payload] = "eyJraWQiOiJZ......"
AppleAuth::ServerIdentity.new(params[:payload]).validate!
>> {iss: "https://appleid.apple.com", exp: 1632224024, iat: 1632137624, jti: "yctpp1ZHaGCzaNB9PWB4DA",...}

# with an invalid JWT
params[:payload] = "asdasdasdasd......"
AppleAuth::ServerIdentity.new(params[:payload]).validate!
>> JWT::VerificationError: Signature verification raised
```

Implementation in a controller would look like this:

```ruby
class Hooks::AuthController < ApplicationController

  skip_before_action :verify_authenticity_token

  # https://developer.apple.com/documentation/sign_in_with_apple/processing_changes_for_sign_in_with_apple_accounts
  # NOTE: The Apple documentation states the events attribute as an array but is in fact a stringified json object
  def apple
    # will raise an error when the signature is invalid
    payload = AppleAuth::ServerIdentity.new(params[:payload]).validate!
    event = JSON.parse(payload[:events]).symbolize_keys
    uid = event["sub"]
    user = User.find_by!(provider: 'apple', uid: uid)

    case event[:type]
    when "email-enabled", "email-disabled"
      # Here we should update the user with the relay state
    when "consent-revoked", "account-delete"
      user.destroy!
    else
      throw event
    end
    render plain: "200 OK", status: :ok
  end
end
```

